### PR TITLE
issue with propertyPlaceholder

### DIFF
--- a/src/main/resources/greeting-context.xml
+++ b/src/main/resources/greeting-context.xml
@@ -12,13 +12,13 @@
         <property name="greeter" ref="myGreeter"/>
     </bean>
     <bean id="reverseProcessor" class="org.learning.camel.bean.ReverseProcessor"/>
-    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">
-        <property name="location" value="classpath:additional.properties"/>
-    </bean>
+<!--    <bean id="properties" class="org.apache.camel.component.properties.PropertiesComponent">-->
+<!--        <property name="location" value="classpath:additional.properties"/>-->
+<!--    </bean>-->
     <camel:camelContext id="camel">
-<!--        <camel:propertyPlaceholder id="properties">-->
-<!--            <camel:propertiesLocation path="classpath:additional.properties"/>-->
-<!--        </camel:propertyPlaceholder>-->
+        <camel:propertyPlaceholder id="properties">
+            <camel:propertiesLocation path="classpath:additional.properties"/>
+        </camel:propertyPlaceholder>
         <camel:packageScan>
             <camel:package>org.learning.camel</camel:package>
         </camel:packageScan>


### PR DESCRIPTION
If I use the property file via main.setPropertyPlaceholderLocations("classpath:[additional.properties](http://additional.properties/)"); or through a Spring bean, everything works fine. But when I try to do it like this:

<camel:propertyPlaceholder id="properties">
 <camel:propertiesLocation path="file://C:/Private/Repos/Camel/src/main/resources/[additional.properties](http://additional.properties/)"/>
</camel:propertyPlaceholder>
—it doesn’t work. And it doesn’t work either with "classpath:[additional.properties](http://additional.properties/)" or when I use the full path.
I've got:
Properties file File://C:/Private/Repos/Camel/src/main/resources/[additional.properties](http://additional.properties/) not found in classpath
What could be the reason?